### PR TITLE
Add build artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+
+# Build and cache directories
+/build
+.phpstan.cache


### PR DESCRIPTION
Prevent build/ directory and PHPStan cache from being tracked in version control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude build artifacts and cache files from version control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->